### PR TITLE
Use subprocess instead of os.system().

### DIFF
--- a/examples/ascad/00-download-data.py
+++ b/examples/ascad/00-download-data.py
@@ -11,13 +11,16 @@ Unzip them...
 """
 import sys
 import os
+import subprocess
 
 if not len(sys.argv) == 2:
     print("Need to specify the location of ASCAD_DIR.")
     print("USAGE: python3 %s ASCAD_DIR"%sys.argv[0])
     exit()
 
+path = os.path.abspath(sys.argv[1])
+zip_path = os.path.join(path, "ASCAD_data.zip")
 
-os.system("wget https://www.data.gouv.fr/s/resources/ascad/20180530-163000/ASCAD_data.zip --directory-prefix=%s"%sys.argv[1])
-os.system("unzip %s/ASCAD_data.zip -d %s"%(sys.argv[1],sys.argv[1]))
-os.system("rm %s/ASCAD_data.zip"%(sys.argv[1]))
+subprocess.call(["wget", "https://www.data.gouv.fr/s/resources/ascad/20180530-163000/ASCAD_data.zip", "--directory-prefix", path])
+subprocess.call(["unzip", zip_path, "-d", path])
+subprocess.call(["rm", zip_path])


### PR DESCRIPTION
Mitigates some potential usability/security issues with, for example, spaces in paths etc.