### PR TITLE
fixed a bug, that caused processings to be applied twice

### DIFF
--- a/lascar/container/container.py
+++ b/lascar/container/container.py
@@ -523,11 +523,9 @@ class AbstractContainer(Container):
 
             trace_batch = self.generate_trace_batch(offset_begin, offset_end)
 
-            for i, j in enumerate(range(offset_begin, offset_end)):
-                leakages[i] = self.apply_both_leakage(trace_batch.leakages[i : i + 1])[
-                    0
-                ]
-                values[i] = self.apply_both_value(trace_batch.values[i : i + 1])[0]
+            leakages = self.apply_both_leakage(trace_batch.leakages)
+            values = self.apply_both_value(trace_batch.values)
+
             return TraceBatchContainer(leakages, values)
 
         except:

--- a/lascar/container/container.py
+++ b/lascar/container/container.py
@@ -461,10 +461,8 @@ class AbstractContainer(Container):
 
         for i, j in enumerate(range(idx_begin, idx_end)):
             leakage, value = self.generate_trace(j)
-            leakages[i] = self.apply_both_leakage(
-                leakage.reshape((1,) + leakage.shape)
-            )[0]
-            values[i] = self.apply_both_value(value.reshape((1,) + value.shape))[0]
+            leakages[i] = leakage
+            values[i] = value
 
         return TraceBatchContainer(leakages, values)
 
@@ -660,7 +658,7 @@ class AbstractArray:
     :class:`lascar.container.container.AbstractContainer`)
     It simply emulates a few methods needed by other classes (such as
     :class:`lascar.session.Session`)
-    
+
     :param shape: the shape of your leakages (or values)
     :param dtype: the dtype of your leakages (or values)
     """

--- a/lascar/container/container.py
+++ b/lascar/container/container.py
@@ -243,7 +243,7 @@ class Container:
         if self.leakage_processing is None:
             return leakages
         if self._leakage_section_abstract.shape == ():  # 0D leakage
-            return self.leakage_processing(leakages)
+            return np.array([self.leakage_processing(l) for l in leakages])
         return np.apply_along_axis(self.leakage_processing, 1, leakages)
 
     def apply_both_leakage(self, leakages):
@@ -332,7 +332,7 @@ class Container:
         if self.value_processing is None:
             return values
         if self._value_section_abstract.shape == ():  # 0D value
-            return self.value_processing(values)
+            return np.array([self.value_processing(v) for v in values])
         return np.apply_along_axis(self.value_processing, 1, values)
 
     def apply_both_value(self, values):


### PR DESCRIPTION
There was a bug, that caused processings to be applied twice to abstract containers, whenever they were used with slices. This was due to the fact, that apply_both was being used in `__getitem__` and a second time in `generate_trace_batch`. I removed it in `generate_trace_batch`, and now everything works fine.

The code below reproduces the bug.

```
from lascar import *
import numpy as np

class myAbstractContainer(AbstractContainer):
    def generate_trace(self, idx):
        return Trace(np.ones(10), np.ones(3))

container = myAbstractContainer(100)

container.leakage_processing = lambda x: 2*x

#we expect both outputs to be identical
print(container[0].leakage)
print(container[0:5].leakages[0])
```

**Edit:**
I found and fixed another bug, in container.py, related to the leakage / value processing of 0D leakages.

For leakage of dimension one or higher, a processing function will always get exactly one leakage as input. But if you have 0D leakages, a processing function would _sometimes_ get multiple leakages as input (During the initialization of the processing function only one leakage, during actual calculations multiple). This is now fixed by a small change in `apply_value_processing`.


**Edit 2:**
Found another minor thing that could be fixed quickly. There was a loop in AbstractContainer's __getitem__ method, that is not needed. Removing it simplifies the code and should reduce overhead.