### PR TITLE
Force numpy version number to be strictly lower than 1.21

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email="charles@ledger.fr, manuel.sanpedro@ledger.fr, victor.servant@ledger.fr",
     install_requires=[
         "click",
-        "numpy>=1.17",
+        "numpy>=1.17,<1.21",
         "h5py",
         "matplotlib",
         "vispy",


### PR DESCRIPTION
As of today, the latest version of numpy (1.21) is not supported by numba, which results on an error when installing

`error: numpy 1.21.2 is installed but numpy<1.21,>=1.17 is required by {'numba'}`

This solution temporary solves the problem until numba updates