### PR TITLE
Remove max version constraint for numpy

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ setup(
     author_email="charles@ledger.fr, manuel.sanpedro@ledger.fr, victor.servant@ledger.fr",
     install_requires=[
         "click",
-        "numpy>=1.17,<1.21",
+        "numpy>=1.17",
         "h5py",
         "matplotlib",
         "vispy",


### PR DESCRIPTION
Numba has been updated and now supports the latest numpy version. 
This constraint is no longer needed 