### PR TITLE
Fixed examples and container improvements

### DIFF
--- a/docs/tutorial_01_discovering_containers.rst
+++ b/docs/tutorial_01_discovering_containers.rst
@@ -138,15 +138,15 @@ instance.
    
    # To work only with the first 10 samples:
    batch.leakage_section = range(10)
-   print(trace_batch)
+   print(batch)
    
    # To work with only with one tenth of the sample:
    batch.leakage_section = range(0, 100, 10)
-   print(trace_batch)
+   print(batch)
    
    # To cancel `leakage_section`:
    batch.leakage_section = None  # cancelling leakage_section
-   print(trace_batch)
+   print(batch)
 
 This will output:
 
@@ -185,7 +185,7 @@ See :code:`lascar/tools/processing` for a list of existing processing.
    )
 
    # Principal component analysis on leakage with 3 components
-   batch.leakage_processing = PcaProcessing(trace_batch, 3)
+   batch.leakage_processing = PcaProcessing(batch, 3)
 
    # No leakage processing
    batch.leakage_processing = None

--- a/docs/tutorial_04_acquisition_setup_example.rst
+++ b/docs/tutorial_04_acquisition_setup_example.rst
@@ -45,9 +45,9 @@ oscilloscope.
            """
            :param number_of_traces: Number of traces in the container
            """
-           super().__init__(self, number_of_traces)
            self.dut = Dut()
            self.oscilloscope = Oscilloscope()
+           super().__init__(number_of_traces)
 
        def generate_trace(self, index: int):
            """

--- a/docs/tutorial_07_dpa_example.rst
+++ b/docs/tutorial_07_dpa_example.rst
@@ -43,7 +43,7 @@ conditioned by a single key byte (256 guesses).
        return sbox[value["plaintext"][3] ^ guess] & 1
 
    guess_range = range(256)
-   dpa_engine = DpaEngine("dpa", selection_function, guess_range)
+   dpa_engine = DpaEngine(selection_function, guess_range)
 
 We can now create a :class:`Session <lascar.session.Session>`, register the
 :code:`dpa_lsb_engine`, and run it:

--- a/docs/tutorial_08_session_outputs.rst
+++ b/docs/tutorial_08_session_outputs.rst
@@ -69,10 +69,10 @@ of the output of the 3rd sbox, the other on the MSB.
        return (sbox[value["plaintext"][3] ^ guess] >> 7) & 1
 
    dpa_lsb_engine = DpaEngine(
-       "dpa_lsb", selection_function_lsb, guess_range, solution=container.key[3]
+       selection_function_lsb, guess_range, solution=container.key[3], name="dpa_lsb"
    )
    dpa_msb_engine = DpaEngine(
-       "dpa_msb", selection_function_lsb, guess_range, solution=container.key[3]
+       selection_function_msb, guess_range, solution=container.key[3], name="dpa_msb"
    )
 
 Dictionnary output

--- a/examples/ascad/02-snr.py
+++ b/examples/ascad/02-snr.py
@@ -36,7 +36,7 @@ filename = ASCAD_DIR + "/ASCAD_data/ASCAD_databases/ATMega8515_raw_traces.h5"
 container = Hdf5Container(
     filename, leakages_dataset_name="traces", values_dataset_name="metadata"
 )
-container = Slice(container, 0, 5000) # only 5000 traces used over the 60000 available
+container = container.limited(5000)  # Only 5000 traces used over the 60000 available
 
 
 """

--- a/examples/ascad/02-snr.py
+++ b/examples/ascad/02-snr.py
@@ -36,7 +36,7 @@ filename = ASCAD_DIR + "/ASCAD_data/ASCAD_databases/ATMega8515_raw_traces.h5"
 container = Hdf5Container(
     filename, leakages_dataset_name="traces", values_dataset_name="metadata"
 )
-container.number_of_traces = 5000  # only 5000 traces used over the 60000 available
+container = Slice(container, 0, 5000) # only 5000 traces used over the 60000 available
 
 
 """
@@ -47,33 +47,33 @@ For each one we specify:
 - the partition_values (range(256) for all of them, since we look at byte values)
 """
 snr_1_engine = SnrEngine(
-    "SNR1: unmasked sbox output",
     lambda value: sbox[value["plaintext"][3] ^ value["key"][3]],  # sbox(p[3] ⊕ k[3])
     range(256),
+    name="SNR1: unmasked sbox output"
 )
 
 snr_2_engine = SnrEngine(
-    "SNR2: masked sbox output",
     lambda value: sbox[value["plaintext"][3] ^ value["key"][3]]
     ^ value["masks"][15],  # sbox(p[3] ⊕ k[3]) ⊕ rout
     range(256),
+    name="SNR2: masked sbox output"
 )
 
 snr_3_engine = SnrEngine(
-    "SNR3: common output mask out", lambda value: value["masks"][15], range(256)  # rout
+    lambda value: value["masks"][15], range(256), name="SNR3: common output mask out"  # rout
 )
 
 snr_4_engine = SnrEngine(
-    "SNR4: masked sbox output in linear parts",
     lambda value: sbox[value["plaintext"][3] ^ value["key"][3]]
     ^ value["masks"][1],  # sbox(p[3] ⊕ k[3]) ⊕ r[3]
     range(256),
+    name="SNR4: masked sbox output in linear parts"
 )
 
 snr_5_engine = SnrEngine(
-    "SNR5: sbox output mask in linear parts",
     lambda value: value["masks"][1],  # r[3]
     range(256),
+    name="SNR5: sbox output mask in linear parts"
 )
 
 engines = [snr_1_engine, snr_2_engine, snr_3_engine, snr_4_engine, snr_5_engine]

--- a/examples/ascad/03-keras-train.py
+++ b/examples/ascad/03-keras-train.py
@@ -70,13 +70,12 @@ partition_values = range(256)  # The range for the labels.
 
 # An engine has to be created, dedicated to the profiling of a classifier (here a keras neural network) with leakages/labels.
 nn_profile_engine = ProfileEngine(
-    "nn_profile",
     nn,
     partition_function,
     partition_values,
     epochs=5,
     batch_size=200,
-    test_size=0.1,
+    test_size=0.1
 )
 
 Session(profiling_container, engine=nn_profile_engine).run()

--- a/examples/ascad/04-keras-test.py
+++ b/examples/ascad/04-keras-test.py
@@ -71,15 +71,15 @@ def guess_function(value, guess):
 guess_range = range(256)  # The possbles value for the guess
 
 # An engine has to be created, dedicated to use a classifier (here a keras neural network nn) with Side-Channel Traces.
-nn_match_engine = MatchEngine(
-    "nn_match", nn, guess_function, guess_range, solution=solution
-)
+nn_match_engine = MatchEngine(nn, guess_function, guess_range, solution=solution, name="nn_match")
 
 
 # Now, 5 times in a row we randomly take 2000 traces from attack_container, and compute the mean rank of the correct key, every 10 traces.
 ranks = []
 
-for i,container in enumerate(split_container(attack_container, size_of_splits=2000)[:5]):
+for i, container in enumerate(
+    split_container(attack_container, size_of_splits=2000)[:5]
+):
 
     session = Session(
         container,

--- a/examples/ascad/05-cpa-high-order.py
+++ b/examples/ascad/05-cpa-high-order.py
@@ -40,7 +40,7 @@ container = Hdf5Container(
     leakage_section=poi,
 )
 
-container = Slice(container, 0, 500)
+container = container.limited(500)
 
 # Then we make a container that will apply a CenteredProduct to recombine all the points of interest.
 container.leakage_processing = CenteredProductProcessing(container)

--- a/examples/ascad/05-cpa-high-order.py
+++ b/examples/ascad/05-cpa-high-order.py
@@ -40,7 +40,7 @@ container = Hdf5Container(
     leakage_section=poi,
 )
 
-container.number_of_traces = 500
+container = Slice(container, 0, 500)
 
 # Then we make a container that will apply a CenteredProduct to recombine all the points of interest.
 container.leakage_processing = CenteredProductProcessing(container)
@@ -48,10 +48,10 @@ container.leakage_processing = CenteredProductProcessing(container)
 
 # Now a classical CPA, targetting the output of the 3rd Sbox:
 cpa_engine = CpaEngine(
-    "cpa-high-order",
     lambda value, guess: hamming(sbox[value["plaintext"][3] ^ guess]),
     range(256),
     solution=container[0].value["key"][3],
+    name="cpa-high-order",
     jit=False,
 )
 

--- a/examples/base/lra.py
+++ b/examples/base/lra.py
@@ -18,14 +18,8 @@ partition_size = 256
 guess_range = range(256)
 
 leakage_model = HammingPrecomputedModel()
-
-container = BasicAesSimulationContainer(
-    5000, 0
-)  
-
-attack = LraEngine(
-    "lra", partition, partition_size, guess_function, guess_range
-)
+container = BasicAesSimulationContainer(5000, 0)
+attack = LraEngine("lra", partition, partition_size, guess_function, guess_range)
 
 session = Session(container)
 session.add_engine(attack)

--- a/examples/base/ttest.py
+++ b/examples/base/ttest.py
@@ -41,7 +41,6 @@ def get_partition_function(byte):
     return partition_function
 
 
-number_of_partitions = 2  # number of possible classes (~output of the partiton_function) for the partition_function
 ttest_engines = [
     TTestEngine(get_partition_function(i)) for i in range(16)
 ]

--- a/examples/rainbow/rainbow_stm32.py
+++ b/examples/rainbow/rainbow_stm32.py
@@ -111,7 +111,6 @@ if __name__ == "__main__":
 
     container = RainbowSubBytesContainer(250)
     engine = CpaEngine(
-        "cpa byte 5",
         lambda value, secret: sbox[value["plaintext"][5] ^ secret],
         range(256),
         solution=42,

--- a/lascar/container/__init__.py
+++ b/lascar/container/__init__.py
@@ -24,6 +24,7 @@ Various format, mechanisms to read, write, acquire, simulate side channel data.
 from .container import AbstractContainer
 from .container import Container
 from .container import TraceBatchContainer
+from .container import Slice 
 from .filtered_container import FilteredContainer
 from .filtered_container import RandomizedContainer
 from .filtered_container import split_container

--- a/lascar/container/container.py
+++ b/lascar/container/container.py
@@ -390,6 +390,25 @@ class Container:
         session = Session(self).run()
         return session["mean"].finalize(), session["var"].finalize()
 
+    def sliced(self, start: int, stop: int) -> Slice:
+        """
+        Wraps the current container in a :class:`Slice` to select a slice of the
+        traces.
+
+        :param start: Start index
+        :param stop: End index, excluded.
+        """
+        return Slice(self, start, stop)
+
+    def limited(self, count: int) -> Slice:
+        """
+        Wraps the current container in a :class:`Slice` to limit the number of
+        traces.
+
+        :param count: Number of traces limit.
+        """
+        return Slice(self, 0, count)
+
 
 # def to_trace(func):
 #     def wrapper(*args, **kwargs):

--- a/lascar/container/container.py
+++ b/lascar/container/container.py
@@ -390,7 +390,7 @@ class Container:
         session = Session(self).run()
         return session["mean"].finalize(), session["var"].finalize()
 
-    def sliced(self, start: int, stop: int) -> Slice:
+    def sliced(self, start: int, stop: int) -> "Slice":
         """
         Wraps the current container in a :class:`Slice` to select a slice of the
         traces.
@@ -400,7 +400,7 @@ class Container:
         """
         return Slice(self, start, stop)
 
-    def limited(self, count: int) -> Slice:
+    def limited(self, count: int) -> "Slice":
         """
         Wraps the current container in a :class:`Slice` to limit the number of
         traces.

--- a/lascar/container/filtered_container.py
+++ b/lascar/container/filtered_container.py
@@ -73,7 +73,7 @@ class RandomizedContainer(FilteredContainer):
 
     def __init__(self, container, **kwargs):
         FilteredContainer.__init__(
-            self, container, np.random.permutation(container.number_of_traces), **kwargs
+            self, container, np.random.permutation(len(container)), **kwargs
         )
 
 
@@ -84,7 +84,7 @@ def split_container(container, random=True, **kwargs):
     :param kwargs: specify either the number of splits (number_of_splits), or the size of each split (size_of_splits)
     :return: a list of number_of_splits containers OR a list of containers of size_of_splits each.
     """
-    n = container.number_of_traces
+    n = len(container)
     if random:
         indexes = np.random.permutation(n)
     else:

--- a/lascar/container/hdf5_container.py
+++ b/lascar/container/hdf5_container.py
@@ -71,6 +71,9 @@ class Hdf5Container(Container):
     def __setitem__(self, key, value):
         TraceBatchContainer.__setitem__(self, key, value)
 
+    def __len__(self):
+        return len(self.leakages)
+
     @staticmethod
     def void_container(
         filename,
@@ -143,7 +146,7 @@ class Hdf5Container(Container):
         leakage, value = container[0]
         out = Hdf5Container.void_container(
             filename,
-            container.number_of_traces,
+            len(container),
             leakage.shape,
             leakage.dtype,
             value.shape,

--- a/lascar/container/npy_container.py
+++ b/lascar/container/npy_container.py
@@ -55,6 +55,9 @@ class NpyContainer(Container):
     def __setitem__(self, key, value):
         TraceBatchContainer.__setitem__(self, key, value)
 
+    def __len__(self):
+        return len(self.leakages)
+
     def _void_container(
         leakages_filename,
         values_filename,
@@ -108,7 +111,7 @@ class NpyContainer(Container):
         out = NpyContainer._void_container(
             leakages_filename,
             values_filename,
-            container.number_of_traces,
+            len(container),
             leakage.shape,
             leakage.dtype,
             value.shape,

--- a/lascar/engine/classifier_engine.py
+++ b/lascar/engine/classifier_engine.py
@@ -87,8 +87,7 @@ class ProfileEngine(PartitionerEngine):
         self.batch_size = batch_size
 
     def _initialize(self):
-
-        self._session._batch_size = self._session.container.number_of_traces
+        self._session._batch_size = len(self._session.container)
         self._session._thread_on_update = False
         if self.classifier_type == "keras":
             self._session._progressbar = None
@@ -161,7 +160,7 @@ class MatchEngine(GuessEngine):
 
     def _initialize(self):
         self._log_probas = np.zeros((self._number_of_guesses,))
-        self._session._batch_size = self._session.container.number_of_traces
+        self._session._batch_size = len(self._session.container)
         self._session._thread_on_update = False
 
     def _update(self, batch):

--- a/lascar/engine/lra_engine.py
+++ b/lascar/engine/lra_engine.py
@@ -72,8 +72,8 @@ class LraEngine(PartitionerEngine,GuessEngine):
         :param regression_order: the regression order (by default =1)
         :param size_target_value: the number of bits of the target value, that we are regressing (by default = 8). 
         """
-        PartitionerEngine.__init__(self, name, partition_function, partition_range, 2)
-        GuessEngine.__init__(self, name, selection_function, guess_range, solution)
+        PartitionerEngine.__init__(self, partition_function, partition_range, 2, name=name)
+        GuessEngine.__init__(self, selection_function, guess_range, solution=solution, name=name)
         self.logger.debug(
             'Creating LraEngine "%s" with %d partitions, %d guesses.'
             % (name, len(self._partition_range), len(guess_range))

--- a/lascar/session.py
+++ b/lascar/session.py
@@ -68,8 +68,10 @@ class Session:
         self.logger.debug("Creating Session.")
 
         self.container = container
-        self.leakage_shape = container._leakage_abstract.shape
-        self.value_shape = container._value_abstract.shape
+
+        leakage_0, value_0 = container[0]
+        self.leakage_shape = leakage_0.shape
+        self.value_shape = value_0.shape
 
         self.name = name
 
@@ -115,15 +117,15 @@ class Session:
     def output_steps(self, output_steps):
         if isinstance(output_steps, int):
             self._output_steps = list(
-                range(output_steps, self.container.number_of_traces + 1, output_steps)
+                range(output_steps, len(self.container) + 1, output_steps)
             )
         elif hasattr(output_steps, "__iter__"):
             self._output_steps = [i for i in output_steps]
         else:
             self._output_steps = []
 
-        if not self.container.number_of_traces in self._output_steps:
-            self._output_steps.append(self.container.number_of_traces)
+        if not len(self.container) in self._output_steps:
+            self._output_steps.append(len(self.container))
         self._output_steps.sort()
 
     def add_engine(self, engine):
@@ -159,9 +161,9 @@ class Session:
         batch_offsets = []
         offset = 0
 
-        while offset < self.container.number_of_traces:
-            if offset + batch_size > self.container.number_of_traces:
-                batch_offsets.append((offset, self.container.number_of_traces))
+        while offset < len(self.container):
+            if offset + batch_size > len(self.container):
+                batch_offsets.append((offset, len(self.container)))
 
             else:
                 batch_offsets.append((offset, offset + batch_size))
@@ -226,7 +228,7 @@ class Session:
             "Session %s: %d traces, %d engines, batch_size=%d, leakage_shape=%s"
             % (
                 self.name,
-                self.container.number_of_traces,
+                len(self.container),
                 len(self.engines),
                 self._batch_size,
                 self.leakage_shape,

--- a/lascar/tools/processing.py
+++ b/lascar/tools/processing.py
@@ -76,7 +76,7 @@ class CenteredProductProcessing(Processing):
         session = Session(container, name="CenteredProduct:")
         session.run(batch_size)
         self.mean = session["mean"].finalize()
-        number_of_leakage_samples = container._leakage_abstract.shape[0]
+        number_of_leakage_samples = container[0][0].shape[0]
 
         if rois is None:
             self.order = order
@@ -119,7 +119,7 @@ class PcaProcessing(Processing):
         self._pca = PCA(n_components=number_of_components, random_state=random_state)
 
         # compute pca:
-        batch = container[: container.number_of_traces]
+        batch = container[: len(container)]
         self._pca.fit(batch.leakages)
 
         self.post_section = post_section
@@ -156,7 +156,7 @@ class IcaProcessing(Processing):
         )
 
         # compute ica:
-        batch = container[: container.number_of_traces]
+        batch = container[: len(container)]
         self._ica.fit(batch.leakages)
 
         self.post_section = post_section

--- a/tests/test_container.py
+++ b/tests/test_container.py
@@ -112,7 +112,7 @@ class TestContainerLeakageProcessing:
         leakage_processing = StandardScalerProcessing(container)
         container.leakage_processing = leakage_processing
 
-        batch = container[: container.number_of_traces]
+        batch = container[: len(container)]
         leakages_centered_reduced = (leakages - leakages.mean(0)) / leakages.std(0)
         assert np.all(np.isclose(batch.leakages, leakages_centered_reduced))
 
@@ -143,7 +143,7 @@ class TestContainerLeakageProcessing:
         container.leakage_processing = leakage_processing
         leakages_centered = leakages - leakages.mean(0)
 
-        batch = container[: container.number_of_traces]
+        batch = container[: len(container)]
         for i, combination in enumerate(leakage_processing.combinations):
             assert np.all(
                 batch.leakages[:, i]

--- a/tutorial/01-discovering-containers.py
+++ b/tutorial/01-discovering-containers.py
@@ -114,7 +114,7 @@ batch.leakage_processing = CenteredProductProcessing(batch, [[0, 1, 2], [3, 4, 5
 print(batch)
 
 # Principal component analysis on leakage with 3 components
-batch.leakage_processing = PcaProcessing(trace_batch, 3)
+batch.leakage_processing = PcaProcessing(batch, 3)
 print(batch)
 
 # No leakage processing

--- a/tutorial/04-acquisition-setup-example.py
+++ b/tutorial/04-acquisition-setup-example.py
@@ -42,9 +42,9 @@ class AcquisitionSetup(AbstractContainer):
         """
         :param number_of_traces: Number of traces in the container
         """
-        super().__init__(self, number_of_traces)
         self.dut = Dut()
         self.oscilloscope = Oscilloscope()
+        super().__init__(number_of_traces)
 
     def generate_trace(self, index: int):
         """
@@ -66,8 +66,8 @@ acquisition = AcquisitionSetup(100)
 
 # This container is Abstract. Its 100 traces are stored nowhere, yet they can be
 # accessed:
-print("trace 0:", acquisition_container[0])
-print("trace 10:", acquisition_container[10])
+print("trace 0:", acquisition[0])
+print("trace 10:", acquisition[10])
 
 # More importantly, this container can be converted to a Hdf5Container, so the
 # traces get saved to the disk. The export method takes here all its sense.

--- a/tutorial/07-session-dpa-example.py
+++ b/tutorial/07-session-dpa-example.py
@@ -33,7 +33,7 @@ def selection_function(value, guess):
 
 
 guess_range = range(256)
-dpa_engine = DpaEngine("dpa", selection_function, guess_range)
+dpa_engine = DpaEngine(selection_function, guess_range)
 
 # We can now create a Session, register the dpa_lsb_engine, and run it.
 

--- a/tutorial/08-session-manage-outputs.py
+++ b/tutorial/08-session-manage-outputs.py
@@ -56,10 +56,10 @@ def selection_function_msb(value, guess):
 
 
 dpa_lsb_engine = DpaEngine(
-    "dpa_lsb", selection_function_lsb, guess_range, solution=container.key[3]
+    selection_function_lsb, guess_range, solution=container.key[3], name="dpa_lsb"
 )
 dpa_msb_engine = DpaEngine(
-    "dpa_msb", selection_function_lsb, guess_range, solution=container.key[3]
+    selection_function_msb, guess_range, solution=container.key[3], name="dpa_msb"
 )
 
 # DictOutputMethod:


### PR DESCRIPTION
This PR fixes broken examples due to recent breaking changes.

It also replaces the `number_of_traces` attributes by implementing the `__len__` method in each container class, which is more pythonic.

Finally, as modifying `number_of_traces` could be used to limit the number of traces for an analysis, this must now be done by using the new class `Slice` which wraps an existing container. Any container has `sliced(start, stop)` and `limited(count)` shortcut methods to wrap the container in a `Slice`.